### PR TITLE
Add name attribute to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "locale"
 maintainer       "Heavy Water Software Inc."
 maintainer_email "darrin@heavywater.ca"
 license          "Apache 2.0"


### PR DESCRIPTION
Ridley and potentially other libraries need the name attribute in the metadata.
