### PR TITLE
don’t raise exception when `file_path` is missing

### DIFF
--- a/libraries/locale.rb
+++ b/libraries/locale.rb
@@ -1,6 +1,8 @@
 module Locale
   class << self
     def up_to_date?(file_path, lang, lc_all)
+      return false unless ::File.exist?(file_path)
+
       locale = IO.read(file_path)
       locale.include?("LANG=#{lang}") && locale.include?("LC_ALL=#{lc_all}")
     end


### PR DESCRIPTION
`IO.read` raises if `file_path` doesn't exist. This PR add a guard against that.
