### PR TITLE
A missing file should be considered false when checking up_to_date?

### DIFF
--- a/libraries/locale.rb
+++ b/libraries/locale.rb
@@ -1,8 +1,12 @@
 module Locale
   class << self
     def up_to_date?(file_path, lang, lc_all)
-      locale = IO.read(file_path)
-      locale.include?("LANG=#{lang}") && locale.include?("LC_ALL=#{lc_all}")
+      begin
+        locale = IO.read(file_path)
+        locale.include?("LANG=#{lang}") && locale.include?("LC_ALL=#{lc_all}")
+      rescue Errno::ENOENT
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
On a Centos 5.9 AMI in AWS the i18n file is not there by default.  IF this is the case we should consider the file as not being up to date and write it.  
