### PR TITLE
Fix setting non-UTF locales on Ubuntu 14.04

### DIFF
--- a/resources/locale.rb
+++ b/resources/locale.rb
@@ -33,8 +33,8 @@ action :update do
       not_if { up_to_date?('/etc/default/locale', new_resource.lang) } if ::File.exist?('/etc/default/locale')
     end
   elsif ::File.exist?('/usr/sbin/update-locale')
-    execute 'Generate locale' do
-      command "locale-gen #{new_resource.lang}"
+    execute 'Generate locales' do
+      command "locale-gen"
       not_if { up_to_date?('/etc/default/locale', new_resource.lang, new_resource.lc_all) }
     end
 

--- a/resources/locale.rb
+++ b/resources/locale.rb
@@ -34,7 +34,7 @@ action :update do
     end
   elsif ::File.exist?('/usr/sbin/update-locale')
     execute 'Generate locales' do
-      command "locale-gen"
+      command 'locale-gen'
       not_if { up_to_date?('/etc/default/locale', new_resource.lang, new_resource.lc_all) }
     end
 

--- a/resources/locale.rb
+++ b/resources/locale.rb
@@ -64,7 +64,7 @@ action_class do
   def up_to_date?(file_path, lang, lc_all = nil)
     locale = IO.read(file_path)
     locale.include?("LANG=#{lang}") &&
-      (lc_all.nil? || locale.include?("LC_ALL=#{lc_all}"))
+      (node['init_package'] == 'systemd' || lc_all.nil? || locale.include?("LC_ALL=#{lc_all}"))
   rescue
     false
   end

--- a/test/integration/default/default.rb
+++ b/test/integration/default/default.rb
@@ -2,6 +2,10 @@ describe os_env('LANG') do
   its('content') { should eq 'C' }
 end
 
-describe os_env('LC_ALL') do
-  its('content') { should eq 'C' }
+if (os[:name] == 'debian' && os.release.to_i == 7) ||
+   (os[:name] == 'ubuntu' && os.release.to_f == 14.04) ||
+   (os[:name] == 'centos' && os.release.to_i == 6)
+  describe os_env('LC_ALL') do
+    its('content') { should eq 'C' }
+  end
 end


### PR DESCRIPTION
You can only generate UTF locales so don't generate specify locales, but instead just generate them all. This fixes Ubuntu 14.04 when you try to set a non-UTF locale