### PR TITLE
Fix Travis Builds on Debian family

### DIFF
--- a/resources/locale.rb
+++ b/resources/locale.rb
@@ -24,7 +24,7 @@ property :lang, String, default: 'en_US.utf8'
 property :lc_all, String, default: 'en_US.utf8'
 
 action :update do
-  if node['init_package'] == 'systemd'
+  if node['init_package'] == 'systemd' && ::File.exit?('/usr/bin/localectl')
     # on systemd settings LC_ALL is (correctly) reserved only for testing and cannot be set globally
     execute "localectl set-locale LANG=#{new_resource.lang}" do
       # RHEL uses /etc/locale.conf


### PR DESCRIPTION
### Description

Fix Travis Builds on Debian family, it detects systemd but localectl does not exists

### Check List

- [ ] All tests pass.
- [x] All commits have been signed for the Developer Certificate of Origin.
