### PR TITLE
Fix localctl failing in Docker

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -33,6 +33,7 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/touch /etc/default/keyboard
       - RUN /usr/bin/apt-get install dbus locales -y
 
 - name: debian-9
@@ -41,6 +42,7 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/touch /etc/default/keyboard
       - RUN /usr/bin/apt-get install dbus locales -y
 
 - name: centos-6
@@ -64,6 +66,8 @@ platforms:
     pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/touch /etc/default/keyboard
+      - RUN /usr/bin/apt-get install dbus locales -y
 
 - name: ubuntu-16.04
   driver:
@@ -71,6 +75,8 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/touch /etc/default/keyboard
+      - RUN /usr/bin/apt-get install dbus locales -y
 
 - name: opensuse-leap
   driver:


### PR DESCRIPTION
This is straight up embarassing on systemd's part. If localectl can't
find /etc/default/keyboard it fails with a dbus error. The file can be
empty. It just has to be there.

Signed-off-by: Tim Smith <tsmith@chef.io>